### PR TITLE
Purchase requestの変更

### DIFF
--- a/entities_and_relations.md
+++ b/entities_and_relations.md
@@ -70,6 +70,7 @@
 | `purchase_request_id` | TEXT     | PRIMARY KEY          | 申請のユニークID                                                            |
 | `applicant_id`        | TEXT     | FOREIGN KEY          | 申請者のID（Userへの外部キー）                                              |
 | `product_name`        | TEXT     | NOT NULL             | 申請された製品名                                                            |
+| `model_number`        | TEXT     |                      | 型番                                                                        |
 | `cost`                | INT      | COST>=0              | 申請された購入費用                                                          |
 | `disposer_id`         | TEXT     | FOREIGN KEY          | 廃棄責任者のID（Userへの外部キー）                                          |
 | `status_id`           | TEXT     | FOREIGN KEY          | 購入申請状態ID（Statusへの外部キー、pending(保留)やapproved(承認済み)など） |

--- a/entities_and_relations.md
+++ b/entities_and_relations.md
@@ -72,7 +72,6 @@
 | `product_name`        | TEXT     | NOT NULL             | 申請された製品名                                                            |
 | `model_number`        | TEXT     |                      | 型番                                                                        |
 | `cost`                | INT      | COST>=0              | 申請された購入費用                                                          |
-| `disposer_id`         | TEXT     | FOREIGN KEY          | 廃棄責任者のID（Userへの外部キー）                                          |
 | `status_id`           | TEXT     | FOREIGN KEY          | 購入申請状態ID（Statusへの外部キー、pending(保留)やapproved(承認済み)など） |
 | `request_date`        | DATE     | DEFAULT CURRENT_DATE | 申請作成日                                                                  |
 | `approval_date`       | DATE     |                      | 承認日                                                                      |


### PR DESCRIPTION
変更1. 製品テーブルには型番があるのに、購入申請テーブルには型番がないので、購入申請から自動入力することを考えるとまずいと思うので変更してほしい。

変更2. 購入申請に廃棄責任者がいるがこれは、製品テーブルでの所有者が廃棄するのが自然だと思うのですがどうですかね。
その場合、購入申請に廃棄責任者が不要になると思います。